### PR TITLE
Progress on hiding contact info

### DIFF
--- a/src/components/Account/account.css
+++ b/src/components/Account/account.css
@@ -31,7 +31,7 @@
 
 .accountName {
     padding-top: 10%;
-    padding-left: 40%;
+    padding-left: 54%;
     color: rgb(90, 114, 141);
     font-family: Arial, Helvetica, sans-serif;
 }

--- a/src/components/Home/index.css
+++ b/src/components/Home/index.css
@@ -90,13 +90,13 @@
 
 .userName {
     font-size: 18px;
-    padding-left: 45%;
+    margin-left: 15%;
     padding-top: 13%;
 }
 
-.ratingTitle {
+.rating {
     padding-top: 2%;
-    padding-left: 46%;
+    margin-left: 10%;
 }
 
 h5 {

--- a/src/components/Settings/index.css
+++ b/src/components/Settings/index.css
@@ -41,13 +41,17 @@ hr {
     margin: 0;
     margin-bottom: 13%;
     padding-right: 5%;
+    position: relative;
+    top: 50%; 
+    transform: translateY(-50%);
+    -webkit-transform: translateY(-50%);
 }
 
 .align {
-    width: 70%;
-    margin-bottom: 5.9%;
-    margin-left: 5%;
-    height: 5.65%;
+    width: 95%;
+    margin-top: 3%;
+    margin-left: 2%;
+    height: 50%;
     border: black solid 1px;
     border-radius: 3px;
     padding-left: 5px;
@@ -97,3 +101,106 @@ hr {
     color: white;
     border: gray solid 1px;
 }
+
+.rowSettings {
+    height: 8%;
+    width: 100%;
+}
+
+.colLabels {
+    height: 100%;
+    width: 30%;
+    text-align: right;
+    vertical-align: middle;
+    float: left;
+    
+}
+
+.colInput {
+    height: 100%;
+    width: 45%;
+    float: left;
+}
+
+.colHidden {
+    height: 100%;
+    width: 25%;
+    float: left;
+}
+
+.hidden {
+    margin-top: 3px;
+    margin-bottom: 3px;
+    margin-left: 8px;
+    font-size: 15px;
+    color: rgb(90, 114, 141);
+    float: left;
+    top: 50%; 
+    transform: translateY(50%);
+    -webkit-transform: translateY(50%);
+}
+
+checkbox {
+    float: left;
+}
+
+/* CSS FOR SLIDER BOXES */
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 50px;
+    height: 22px;
+    margin-top: 6.5%;
+    margin-left: 7%;
+  }
+  
+  /* Hide default HTML checkbox */
+  .switch input {display:none;}
+  
+  /* The slider */
+  .slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    -webkit-transition: .4s;
+    transition: .4s;
+  }
+  
+  .slider:before {
+    position: absolute;
+    content: "";
+    height: 15px;
+    width: 15px;
+    left: 4px;
+    bottom: 4px;
+    background-color: white;
+    -webkit-transition: .4s;
+    transition: .4s;
+  }
+  
+  input:checked + .slider {
+    background-color: #2196F3;
+  }
+  
+  input:focus + .slider {
+    box-shadow: 0 0 1px #2196F3;
+  }
+  
+  input:checked + .slider:before {
+    -webkit-transform: translateX(26px);
+    -ms-transform: translateX(26px);
+    transform: translateX(26px);
+  }
+  
+  /* Rounded sliders */
+  .slider.round {
+    border-radius: 34px;
+  }
+  
+  .slider.round:before {
+    border-radius: 50%;
+  }

--- a/src/components/Settings/index.js
+++ b/src/components/Settings/index.js
@@ -92,24 +92,90 @@ class SettingsPage extends Component {
 					<form className="settingsForm">
 						<h4>Account Settings</h4>
 						<hr></hr>
-						<div className="columnLeft">
-							<p className="labels">Display Name</p>
-							<p className="labels">Photo URL</p>
-							<p className="labels">Address</p>
-							<p className="labels">Phone Number</p>
-							<p className="labels">Latitude</p>
-							<p className="labels">Longitude</p>
-							<p className="labels">Radius (m)</p>
+						{/*DISPLAY NAME*/}
+						<div className="rowSettings">
+							<div className="colLabels">
+								<p className="labels">Display Name</p>
+							</div>
+							<div className="colInput">
+								<input className="align" type="text" id="displayName" onChange={this.onChange} value={this.state.displayName}/><br/>
+							</div>
 						</div>
-						<div className="columnRight">
-							<input className="align" type="text" id="displayName" onChange={this.onChange} value={this.state.displayName}/><br/>
-							<input className="align" type="url" id="photoUrl" onChange={this.onChange} value={this.state.photoUrl}/><br/>
-							<input className="align" type="text" id="address" onChange={this.onChange} value={this.state.contactInfo.address}/><br/>
-							<input className="align" type="tel" id="phoneNumber" onChange={this.onChange} value={this.state.contactInfo.phoneNumber}/><br/>
-							<input className="align" type="number" id="lat" onChange={this.onChange} value={this.state.lat}/><br/>
-							<input className="align" type="number" id="lng" onChange={this.onChange} value={this.state.lng}/><br/>
-							<input className="align" type="number" id="radius" onChange={this.onChange} value={this.state.radius}/>
+
+						{/*PHOTO URL*/}
+						<div className="rowSettings">
+							<div className="colLabels">
+								<p className="labels">Photo URL</p>
+							</div>
+							<div className="colInput">
+								<input className="align" type="url" id="photoUrl" onChange={this.onChange} value={this.state.photoUrl}/><br/>
+							</div>
 						</div>
+
+						{/*ADDRESS*/}
+						<div className="rowSettings">
+							<div className="colLabels">
+								<p className="labels">Address</p>
+							</div>
+							<div className="colInput">
+								<input className="align" type="text" id="address" onChange={this.onChange} value={this.state.contactInfo.address}/><br/>
+							</div>
+							<div className="colHidden">
+								<p className="hidden">Hide?</p>
+								<label class="switch">
+									<input type="checkbox"/>
+									<span class="slider round"></span>
+								</label>
+							</div>
+						</div>
+
+						{/*PHONE NUMBER*/}
+						<div className="rowSettings">
+							<div className="colLabels">
+								<p className="labels">Phone Number</p>
+							</div>
+							<div className="colInput">
+								<input className="align" type="tel" id="phoneNumber" onChange={this.onChange} value={this.state.contactInfo.phoneNumber}/><br/>
+							</div>
+							<div className="colHidden">
+								<p className="hidden">Hide?</p>
+								<label class="switch">
+									<input type="checkbox"/>
+									<span class="slider round"></span>
+								</label>
+							</div>
+						</div>
+
+						{/*LATITUDE*/}
+						<div className="rowSettings">
+							<div className="colLabels">
+								<p className="labels">Latitude</p>
+							</div>
+							<div className="colInput">
+								<input className="align" type="number" id="lat" onChange={this.onChange} value={this.state.lat}/><br/>
+							</div>
+						</div>
+
+						{/*LONGITUDE*/}
+						<div className="rowSettings">
+							<div className="colLabels">
+								<p className="labels">Longitude</p>
+							</div>
+							<div className="colInput">
+								<input className="align" type="number" id="lng" onChange={this.onChange} value={this.state.lng}/><br/>
+							</div>
+						</div>
+
+						{/*RADIUS*/}
+						<div className="rowSettings">
+							<div className="colLabels">
+								<p className="labels">Radius (m)</p>
+							</div>
+							<div className="colInput">
+								<input className="align" type="number" id="radius" onChange={this.onChange} value={this.state.radius}/>
+							</div>
+						</div>
+
 						<div className="warningForm">
 							{ !!this.state.error ? <p className="warning" style={{'color': 'red'}}>ERROR: {this.state.error}</p> : null }
 						</div>

--- a/src/components/Support/index.css
+++ b/src/components/Support/index.css
@@ -2,6 +2,7 @@
     position: absolute;
     top: 60px;
     bottom: 32px;
+    overflow-y: auto;
     background-color: rgb(238, 237, 237);
     width: 100%;
     height: 100%-32px;
@@ -9,9 +10,20 @@
 
 .headerSupport {
     width: 60%;
+    height: 10%;
+    font-family: Verdana, Arial, Helvetica, sans-serif;
+    font-size: 45px;
+    font-weight: bold;
+    text-align: center;
+    margin: auto;
+    padding-top: 3%;
+}
+
+.headerFrequent {
+    width: 75%;
     height: 15%;
     font-family: Verdana, Arial, Helvetica, sans-serif;
-    font-size: 48px;
+    font-size: 35px;
     font-weight: bold;
     text-align: center;
     margin: auto;

--- a/src/components/Support/index.js
+++ b/src/components/Support/index.js
@@ -31,7 +31,7 @@ class SupportPage extends Component {
               <h2> The 24/7 Bartr support team may be reached at <a href="mailto:BartrTradeHelp@gmail.com">BartrTradeHelp@gmail.com</a> and 
                   will promptly respond to your email. If you need to report a user click <a href="https://docs.google.com/forms/d/e/1FAIpQLScDEeZwyH-fQiDNSUggxKMZFNPm03H9cF3IaI5uwzR7MeECkA/viewform?usp=sf_link" target="_blank">here</a>
               </h2>
-              <div className="headerSupport"> Frequently Asked Questions </div>
+              <div className="headerFrequent"> Frequently Asked Questions </div>
               <div className="FAQ">
                 <h1> Is Bartr free? </h1>
                 <div className="answerText"> YES! Bartr is completely free to use for all members. </div>


### PR DESCRIPTION
-redid settings page, instead of 2 columns and vertical spacing items, its 7 rows broken in to 3 columns each
-added in slider switches for hiding address and/or phone number
-fixed overflow on support page and resized headers